### PR TITLE
Make service depend on package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,8 @@ class apparmor (
 
   if $service_manage {
     service { 'apparmor':
-      ensure => $service_ensure,
+      ensure  => $service_ensure,
+      require => Package['apparmor'],
     }
   }
 


### PR DESCRIPTION
... otherwise Puppet may try to configure the service before the package is installed